### PR TITLE
Add multipart form-data transformations

### DIFF
--- a/lib/transforms/multipart.ts
+++ b/lib/transforms/multipart.ts
@@ -118,13 +118,14 @@ function formDataParser(ct: MultipartContentType): (reader: Reader<Buffer>, writ
             const str = buf.toString('binary');
 
             let endBoundaryIndex = str.indexOf(boundary) + boundary.length;
+            if (endBoundaryIndex < 0) throw new Error('boundary not found');
+
             if (str.charAt(endBoundaryIndex) === '\r') {
                 endBoundaryIndex++;
             }
             if (str.charAt(endBoundaryIndex) === '\n') {
                 endBoundaryIndex++;
             }
-            if (endBoundaryIndex < 0) throw new Error('boundary not found');
 
             if (str.indexOf(boundary + '--') === 0) {
                 return;

--- a/lib/transforms/multipart.ts
+++ b/lib/transforms/multipart.ts
@@ -3,17 +3,24 @@
 /// 
 /// `import { multipartParser, multipartFormatter }from 'f-streams'`  
 /// 
-import { handshake, wait } from 'f-promise';
+import { handshake } from 'f-promise';
 import * as generic from '../devices/generic';
 import * as binary from '../helpers/binary';
 import { Reader } from '../reader';
 import { Writer } from '../writer';
 
-function parseContentType(contentType?: string) {
+type MultipartSubType = 'mixed' | 'form-data';
+
+interface IMultipartContentType {
+    subType: MultipartSubType;
+    boundary: string;
+}
+
+function parseContentType(contentType?: string): IMultipartContentType | null {
 	if (!contentType) throw new Error('content-type missing');
 	const match = /^multipart\/([\w\-]*)/.exec(contentType);
 	if (!match) return null;
-	const subType = match[1];
+	const subType = match[1] as MultipartSubType;
 	const atbs: any = contentType.split(/\s*;\s*/).reduce((r: any, s: string) => {
 		const kv = s.split(/\s*=\s*/);
 		r[kv[0]] = kv[1];
@@ -25,7 +32,193 @@ function parseContentType(contentType?: string) {
 	};
 }
 
-/// * `transform = multipartParser(options)`  
+function mixedParser(ct: IMultipartContentType): (reader: Reader<Buffer>, writer: Writer<any>) => void {
+    const boundary = ct.boundary;
+    return (reader: Reader<Buffer>, writer: Writer<any>) => {
+        const binReader = binary.reader(reader);
+        const hk = handshake();
+        while (true) {
+            const buf = binReader.readData(2048);
+            if (!buf || !buf.length) return;
+            const str = buf.toString('binary');
+            let i = str.indexOf(boundary);
+            if (i < 0) throw new Error('boundary not found');
+            const lines = str.substring(0, i).split(/\r?\n/);
+            const headers = lines.slice(0, lines.length - 2).reduce((h: any, l: string) => {
+                const kv = l.split(/\s*:\s*/);
+                h[kv[0].toLowerCase()] = kv[1];
+                return h;
+            }, {});
+            i = str.indexOf('\n', i);
+            binReader.unread(buf.length - i - 1);
+
+            const read = () => {
+                const len = Math.max(boundary.length, 256);
+                const bbuf = binReader.readData(32 * len);
+                if (!bbuf || !bbuf.length) {
+                    hk.notify();
+                    return;
+                }
+                // would be nice if Buffer had an indexOf. Would avoid a conversion to string.
+                // I could use node-buffertools but it introduces a dependency on a binary module.
+                const s = bbuf.toString('binary');
+                const ii = s.indexOf(boundary);
+                if (ii === 0) {
+                    const j = s.indexOf('\n', boundary.length);
+                    if (j < 0) throw new Error('newline missing after boundary');
+                    binReader.unread(bbuf.length - j - 1);
+                    hk.notify();
+                    return undefined;
+                } else if (ii > 0) {
+                    let j = s.lastIndexOf('\n', ii);
+                    if (s[j - 1] === '\r') j--;
+                    binReader.unread(bbuf.length - ii);
+                    return bbuf.slice(0, j);
+                } else {
+                    binReader.unread(bbuf.length - 31 * len);
+                    return bbuf.slice(0, 31 * len);
+                }
+            };
+            const partReader = generic.reader(read);
+            partReader.headers = headers;
+            writer.write(partReader);
+            hk.wait();
+        }
+    };
+}
+
+function mixedFormatter(ct: IMultipartContentType) {
+    const boundary = ct.boundary;
+    return (reader: Reader<Reader<Buffer>>, writer: Writer<Buffer>) => {
+        let part: Reader<Buffer> | undefined;
+        while ((part = reader.read()) !== undefined) {
+            const headers = part.headers;
+            if (!headers) throw new Error('part does not have headers');
+            Object.keys(part.headers).forEach(key => {
+                writer.write(Buffer.from(key + ': ' + headers[key] + '\n', 'binary'));
+            });
+            writer.write(Buffer.from('\n' + boundary + '\n'));
+            // cannot use pipe because pipe writes undefined at end.
+            part.forEach(data => {
+                writer.write(data);
+            });
+            writer.write(Buffer.from('\n' + boundary + '\n'));
+        }
+    };
+}
+
+function formDataParser(ct: IMultipartContentType): (reader: Reader<Buffer>, writer: Writer<any>) => void {
+    const boundary = '--' + ct.boundary;
+    return (reader: Reader<Buffer>, writer: Writer<any>) => {
+        const binReader = binary.reader(reader);
+        const hk = handshake();
+        while (true) {
+            const buf = binReader.readData(2048);
+            if (!buf || !buf.length) return;
+            const str = buf.toString('binary');
+
+            let endBoundaryIndex = str.indexOf(boundary) + boundary.length;
+            if (str.charAt(endBoundaryIndex) === '\r') {
+                endBoundaryIndex++;
+            }
+            if (str.charAt(endBoundaryIndex) === '\n') {
+                endBoundaryIndex++;
+            }
+            if (endBoundaryIndex < 0) throw new Error('boundary not found');
+
+            if (str.indexOf(boundary + '--') === 0) {
+                return;
+            }
+
+            const endOfHeaders = str.substring(endBoundaryIndex).search(/\r?\n\r?\n/) + endBoundaryIndex;
+
+            const lines = str.substring(endBoundaryIndex, endOfHeaders).split(/\r?\n/);
+            const headers = lines.slice(0, lines.length).reduce((h: any, l: string) => {
+                const kv = l.split(/\s*:\s*/);
+                h[kv[0].toLowerCase()] = kv[1];
+                return h;
+            }, {});
+
+            let beginOfData = endOfHeaders;
+            if (str.charAt(beginOfData) === '\r') {
+                beginOfData++;
+            }
+            if (str.charAt(beginOfData) === '\n') {
+                beginOfData++;
+            }
+            if (str.charAt(beginOfData) === '\r') {
+                beginOfData++;
+            }
+            if (str.charAt(beginOfData) === '\n') {
+                beginOfData++;
+            }
+
+            binReader.unread(buf.length - beginOfData);
+
+            const read = () => {
+                const len = Math.max(boundary.length, 256);
+                const bbuf = binReader.readData(32 * len);
+                if (!bbuf || !bbuf.length) {
+                    hk.notify();
+                    return;
+                }
+                // would be nice if Buffer had an indexOf. Would avoid a conversion to string.
+                // I could use node-buffertools but it introduces a dependency on a binary module.
+                const s = bbuf.toString('binary');
+                const indexOfBoundaryInPart = s.indexOf(boundary);
+
+                if (indexOfBoundaryInPart === 0) {
+                    binReader.unread(bbuf.length);
+                    hk.notify();
+                    return undefined;
+                } else if (indexOfBoundaryInPart > 0) {
+                    let r = 0;
+                    if (s[indexOfBoundaryInPart - 2] === '\r') {
+                        r++;
+                    }
+                    binReader.unread(bbuf.length - indexOfBoundaryInPart);
+                    return bbuf.slice(0, indexOfBoundaryInPart - 1 - r);
+                } else {
+                    binReader.unread(bbuf.length - 31 * len);
+                    return bbuf.slice(0, 31 * len);
+                }
+            };
+            const partReader = generic.reader(read);
+            partReader.headers = headers;
+            writer.write(partReader);
+            hk.wait();
+        }
+    };
+}
+
+function formDataFormatter(ct: IMultipartContentType): (reader: Reader<Reader<Buffer>>, writer: Writer<Buffer>) => void {
+    const boundary = '--' + ct.boundary;
+    if (!boundary) throw new Error('multipart boundary missing');
+    const CR_LF = '\r\n';
+
+    return (reader: Reader<Reader<Buffer>>, writer: Writer<Buffer>) => {
+        let part: Reader<any> | undefined;
+        while ((part = reader.read()) !== undefined) {
+            writer.write(Buffer.from(boundary + CR_LF));
+
+            const headers = part.headers;
+            if (!headers) throw new Error('part does not have headers');
+            Object.keys(part.headers).forEach(key => {
+                writer.write(Buffer.from(key + ': ' + headers[key] + CR_LF, 'binary'));
+            });
+            // cannot use pipe because pipe writes undefined at end.;
+            writer.write(Buffer.from(CR_LF));
+            part.forEach(data => {
+                writer.write(data);
+            });
+            writer.write(Buffer.from(CR_LF));
+
+        }
+        writer.write(Buffer.from(boundary + '--'));
+    };
+}
+
+/// * `transform = multipartParser(options)`
 ///   Creates a parser transform.
 ///   The content type, which includes the boundary,
 ///   is passed via `options['content-type']`.
@@ -33,62 +226,19 @@ export type ParserOptions = {
 	[name: string]: string;
 };
 
-export function parser(options: ParserOptions) {
+export function parser(options: ParserOptions): (reader: Reader<Buffer>, writer: Writer<any>) => void {
 	const ct = parseContentType(options && options['content-type']);
-	const boundary = ct && ct.boundary;
-	if (!boundary) throw new Error('multipart boundary missing');
+	if (!ct || !ct.boundary) throw new Error('multipart boundary missing');
 
-	return (reader: Reader<Buffer>, writer: Writer<any>) => {
-		const binReader = binary.reader(reader);
-		const hk = handshake();
-		while (true) {
-			const buf = binReader.readData(2048);
-			if (!buf || !buf.length) return;
-			const str = buf.toString('binary');
-			let i = str.indexOf(boundary);
-			if (i < 0) throw new Error('boundary not found');
-			const lines = str.substring(0, i).split(/\r?\n/);
-			const headers = lines.slice(0, lines.length - 2).reduce((h: any, l: string) => {
-				const kv = l.split(/\s*:\s*/);
-				h[kv[0].toLowerCase()] = kv[1];
-				return h;
-			}, {});
-			i = str.indexOf('\n', i);
-			binReader.unread(buf.length - i - 1);
-
-			const read = () => {
-				const len = Math.max(boundary.length, 256);
-				const bbuf = binReader.readData(32 * len);
-				if (!bbuf || !bbuf.length) {
-					hk.notify();
-					return;
-				}
-				// would be nice if Buffer had an indexOf. Would avoid a conversion to string.
-				// I could use node-buffertools but it introduces a dependency on a binary module.
-				const s = bbuf.toString('binary');
-				const ii = s.indexOf(boundary);
-				if (ii === 0) {
-					const j = s.indexOf('\n', boundary.length);
-					if (j < 0) throw new Error('newline missing after boundary');
-					binReader.unread(bbuf.length - j - 1);
-					hk.notify();
-					return undefined;
-				} else if (ii > 0) {
-					let j = s.lastIndexOf('\n', ii);
-					if (s[j - 1] === '\r') j--;
-					binReader.unread(bbuf.length - ii);
-					return bbuf.slice(0, j);
-				} else {
-					binReader.unread(bbuf.length - 31 * len);
-					return bbuf.slice(0, 31 * len);
-				}
-			};
-			const partReader = generic.reader(read);
-			partReader.headers = headers;
-			writer.write(partReader);
-			hk.wait();
-		}
-	};
+	const multipartType = (ct && ct.subType) || 'mixed';
+	switch (multipartType) {
+	case 'mixed':
+		return mixedParser(ct);
+	case 'form-data':
+		return formDataParser(ct);
+	default:
+		throw new Error(`Unhandled multipart subtype: ${multipartType}`);
+	}
 }
 
 /// * `transform = multipartFormatter(options)`  
@@ -99,25 +249,17 @@ export interface FormatterOptions {
 	[name: string]: string;
 }
 
-export function formatter(options?: FormatterOptions) {
+export function formatter(options?: FormatterOptions): (reader: Reader<Reader<Buffer>>, writer: Writer<Buffer>) => void {
 	const ct = parseContentType(options && options['content-type']);
-	const boundary = ct && ct.boundary;
-	if (!boundary) throw new Error('multipart boundary missing');
+    if (!ct || !ct.boundary) throw new Error('multipart boundary missing');
 
-	return (reader: Reader<Reader<string>>, writer: Writer<Buffer>) => {
-		let part: Reader<any> | undefined;
-		while ((part = reader.read()) !== undefined) {
-			const headers = part.headers;
-			if (!headers) throw new Error('part does not have headers');
-			Object.keys(part.headers).forEach(key => {
-				writer.write(Buffer.from(key + ': ' + headers[key] + '\n', 'binary'));
-			});
-			writer.write(Buffer.from('\n' + boundary + '\n'));
-			// cannot use pipe because pipe writes undefined at end.
-			part.forEach(data => {
-				writer.write(data);
-			});
-			writer.write(Buffer.from('\n' + boundary + '\n'));
-		}
-	};
+    const multipartType = (ct && ct.subType) || 'mixed';
+    switch (multipartType) {
+    case 'mixed':
+        return mixedFormatter(ct);
+    case 'form-data':
+        return formDataFormatter(ct);
+    default:
+        throw new Error(`Unhandled multipart subtype: ${multipartType}`);
+    }
 }

--- a/lib/transforms/multipart.ts
+++ b/lib/transforms/multipart.ts
@@ -160,7 +160,7 @@ function formDataParser(ct: MultipartContentType): (reader: Reader<Buffer>, writ
                 const bbuf = binReader.readData(32 * len);
                 if (!bbuf || !bbuf.length) {
                     hk.notify();
-                    return;
+                    return undefined;
                 }
                 // would be nice if Buffer had an indexOf. Would avoid a conversion to string.
                 // I could use node-buffertools but it introduces a dependency on a binary module.

--- a/lib/transforms/multipart.ts
+++ b/lib/transforms/multipart.ts
@@ -11,12 +11,12 @@ import { Writer } from '../writer';
 
 type MultipartSubType = 'mixed' | 'form-data';
 
-interface IMultipartContentType {
+interface MultipartContentType {
     subType: MultipartSubType;
     boundary: string;
 }
 
-function parseContentType(contentType?: string): IMultipartContentType | null {
+function parseContentType(contentType?: string): MultipartContentType | null {
 	if (!contentType) throw new Error('content-type missing');
 	const match = /^multipart\/([\w\-]*)/.exec(contentType);
 	if (!match) return null;
@@ -32,7 +32,7 @@ function parseContentType(contentType?: string): IMultipartContentType | null {
 	};
 }
 
-function mixedParser(ct: IMultipartContentType): (reader: Reader<Buffer>, writer: Writer<any>) => void {
+function mixedParser(ct: MultipartContentType): (reader: Reader<Buffer>, writer: Writer<any>) => void {
     const boundary = ct.boundary;
     return (reader: Reader<Buffer>, writer: Writer<any>) => {
         const binReader = binary.reader(reader);
@@ -87,7 +87,7 @@ function mixedParser(ct: IMultipartContentType): (reader: Reader<Buffer>, writer
     };
 }
 
-function mixedFormatter(ct: IMultipartContentType) {
+function mixedFormatter(ct: MultipartContentType) {
     const boundary = ct.boundary;
     return (reader: Reader<Reader<Buffer>>, writer: Writer<Buffer>) => {
         let part: Reader<Buffer> | undefined;
@@ -107,7 +107,7 @@ function mixedFormatter(ct: IMultipartContentType) {
     };
 }
 
-function formDataParser(ct: IMultipartContentType): (reader: Reader<Buffer>, writer: Writer<any>) => void {
+function formDataParser(ct: MultipartContentType): (reader: Reader<Buffer>, writer: Writer<any>) => void {
     const boundary = '--' + ct.boundary;
     return (reader: Reader<Buffer>, writer: Writer<any>) => {
         const binReader = binary.reader(reader);
@@ -191,7 +191,7 @@ function formDataParser(ct: IMultipartContentType): (reader: Reader<Buffer>, wri
     };
 }
 
-function formDataFormatter(ct: IMultipartContentType): (reader: Reader<Reader<Buffer>>, writer: Writer<Buffer>) => void {
+function formDataFormatter(ct: MultipartContentType): (reader: Reader<Reader<Buffer>>, writer: Writer<Buffer>) => void {
     const boundary = '--' + ct.boundary;
     if (!boundary) throw new Error('multipart boundary missing');
     const CR_LF = '\r\n';

--- a/test/unit/multipart-test.ts
+++ b/test/unit/multipart-test.ts
@@ -1,18 +1,17 @@
 import { assert } from 'chai';
 import { setup } from 'f-mocha';
-import { run, wait } from 'f-promise';
 import { bufferReader, bufferWriter, multipartFormatter, multipartParser } from '../..';
 import { IncomingHttpHeaders } from 'http';
 setup();
 
-const { equal, ok, strictEqual, deepEqual } = assert;
+const { equal, ok, strictEqual } = assert;
 
-const boundary = '-- my boundary --';
+const boundary = '------------myBoundary';
 
 function headers(subType: string) {
-	return {
-		'content-type': 'multipart/' + subType + ';atb1=val1; boundary=' + boundary + '; atb2=val2',
-	};
+    return {
+        'content-type': 'multipart/' + subType + ';atb1=val1; boundary=' + boundary + '; atb2=val2',
+    };
 }
 
 type Part = {
@@ -43,6 +42,36 @@ function testStream() {
 		}).join('\n') + '\n\n' + boundary + '\n' + part.body + '\n' + boundary + '\n';
 	}
 	return bufferReader(Buffer.from(parts.map(formatPart).join(''), 'binary'));
+}
+
+function testStreamFormData() {
+    const parts = [{
+        headers: {
+            A: 'VA1',
+            B: 'VB1',
+            'Content-Type': 'text/plain',
+            'content-disposition': 'form-data; name="c1";',
+        },
+        body: 'C1',
+    }, {
+        headers: {
+            'content-type': 'text/plain',
+            'content-disposition': 'form-data; name="c2";',
+            A: 'VA2',
+            B: 'VB2',
+        },
+        body: 'C2',
+    }] as { headers: IncomingHttpHeaders; body: string; }[];
+
+    const CR_LF = '\r\n';
+    function formatPartWithFormData(part: Part) {
+        return CR_LF + '--' + boundary +  CR_LF + Object.keys(part.headers).map(function (name) {
+            return  name + ': ' + part.headers[name];
+        }).join(CR_LF) + CR_LF + CR_LF + part.body;
+    }
+    const arrayBuffer = CR_LF + parts.map(formatPartWithFormData).join('') + CR_LF + '--' + boundary + '--';
+    //  console.log("HEADER", arrayBuffer, "END");
+    return bufferReader(Buffer.from(arrayBuffer, 'binary'));
 }
 
 describe(module.id, () => {
@@ -79,9 +108,50 @@ describe(module.id, () => {
 		const writer = bufferWriter();
 		source.transform(multipartParser(heads)).transform(multipartFormatter(heads)).pipe(writer);
 		const result = writer.toBuffer();
-		strictEqual(result.length, 158);
+		strictEqual(result.length, 178);
 		const writer2 = bufferWriter();
 		bufferReader(result).transform(multipartParser(heads)).transform(multipartFormatter(heads)).pipe(writer2);
 		strictEqual(result.toString('binary'), writer2.toBuffer().toString('binary'));
 	});
+
+    it('basic multipart/form-data', () => {
+        const source = testStreamFormData();
+        const stream = source.transform(multipartParser(headers('form-data')));
+        let part = stream.read();
+        ok(part != null, 'part != null');
+        strictEqual(part.headers.a, 'VA1', 'header A');
+        strictEqual(part.headers.b, 'VB1', 'header B');
+        strictEqual(part.headers['content-type'], 'text/plain', 'content-type');
+        strictEqual(part.headers['content-disposition'], 'form-data; name="c1";', 'content-disposition');
+        let r = part.read();
+        strictEqual(r.toString('binary'), 'C1', 'body C1');
+        r = part.read();
+        strictEqual(r, undefined, 'end of part 1');
+
+        part = stream.read();
+        ok(part != null, 'part != null');
+        strictEqual(part.headers.a, 'VA2', 'header A');
+        strictEqual(part.headers.b, 'VB2', 'header B');
+        strictEqual(part.headers['content-type'], 'text/plain', 'content-type');
+        strictEqual(part.headers['content-disposition'], 'form-data; name="c2";', 'content-disposition');
+        r = part.read();
+        strictEqual(r.toString('binary'), 'C2', 'body C2');
+        r = part.read();
+        strictEqual(r, undefined, 'end of part 2');
+
+        part = stream.read();
+        equal(part, undefined, 'read next part returns undefined');
+    });
+
+    it('multipart/form-data roundtrip', () => {
+        const heads = headers('form-data');
+        const source = testStreamFormData();
+        const writer = bufferWriter();
+        source.transform(multipartParser(heads)).transform(multipartFormatter(heads)).pipe(writer);
+        const result = writer.toBuffer();
+        strictEqual(result.length, 262);
+        const writer2 = bufferWriter();
+        bufferReader(result).transform(multipartParser(heads)).transform(multipartFormatter(heads)).pipe(writer2);
+        strictEqual(result.toString('binary'), writer2.toBuffer().toString('binary'));
+    });
 });

--- a/test/unit/multipart-test.ts
+++ b/test/unit/multipart-test.ts
@@ -99,7 +99,7 @@ describe(module.id, () => {
 		strictEqual(r, undefined, 'end of part 2');
 
 		part = stream.read();
-		equal(part, undefined, 'read next part returns undefined');
+		assert.isUndefined(part);
 	});
 
 	it('multipart/mixed roundtrip', () => {
@@ -140,7 +140,7 @@ describe(module.id, () => {
         strictEqual(r, undefined, 'end of part 2');
 
         part = stream.read();
-        equal(part, undefined, 'read next part returns undefined');
+        assert.isUndefined(part);
     });
 
     it('multipart/form-data roundtrip', () => {


### PR DESCRIPTION
The API remains the same, but the parser/formatter algorithm depends on multipart sub type.

Two sub types can now be managed : 
- mixed
- form-data