### PR TITLE
Fix: multipart parser

### DIFF
--- a/test/unit/multipart-test.ts
+++ b/test/unit/multipart-test.ts
@@ -1,10 +1,20 @@
 import { assert } from 'chai';
 import { setup } from 'f-mocha';
-import { bufferReader, bufferWriter, multipartFormatter, multipartParser } from '../..';
+import { wait } from 'f-promise';
+import {
+    bufferReader,
+    bufferWriter,
+    multipartFormatter,
+    multipartParser,
+    Reader,
+    Writer,
+    BinaryReader,
+    binaryReader,
+} from '../..';
 import { IncomingHttpHeaders } from 'http';
 setup();
 
-const { equal, ok, strictEqual } = assert;
+const { ok, strictEqual } = assert;
 
 const boundary = '------------myBoundary';
 
@@ -19,7 +29,7 @@ type Part = {
     body: string;
 };
 
-function testStream() {
+function testStreamMixed(body1?: string, body2?: string) {
     const parts = [
         {
             headers: {
@@ -27,7 +37,7 @@ function testStream() {
                 B: 'VB1',
                 'Content-Type': 'text/plain',
             },
-            body: 'C1',
+            body: body1 || 'C1',
         },
         {
             headers: {
@@ -35,7 +45,7 @@ function testStream() {
                 A: 'VA2',
                 B: 'VB2',
             },
-            body: 'C2',
+            body: body2 || 'C2',
         },
     ] as { headers: IncomingHttpHeaders; body: string }[];
 
@@ -58,7 +68,7 @@ function testStream() {
     return bufferReader(Buffer.from(parts.map(formatPart).join(''), 'binary'));
 }
 
-function testStreamFormData() {
+function testStreamFormData(body1?: string, body2?: string): Reader<Buffer> {
     const parts = [
         {
             headers: {
@@ -67,7 +77,7 @@ function testStreamFormData() {
                 'Content-Type': 'text/plain',
                 'content-disposition': 'form-data; name="c1";',
             },
-            body: 'C1',
+            body: body1 || 'C1',
         },
         {
             headers: {
@@ -76,7 +86,7 @@ function testStreamFormData() {
                 A: 'VA2',
                 B: 'VB2',
             },
-            body: 'C2',
+            body: body2 || 'C2',
         },
     ] as { headers: IncomingHttpHeaders; body: string }[];
 
@@ -102,9 +112,29 @@ function testStreamFormData() {
     return bufferReader(Buffer.from(arrayBuffer, 'binary'));
 }
 
+function yieldMapper(buffer: Buffer) {
+    wait(cb => setImmediate(cb));
+    return buffer;
+}
+
+function binaryToBufferReaderTransformer(reader: BinaryReader, writer: Writer<Buffer>) {
+    let chunkSize = 40 * 1024;
+    // With our setting:
+    // - read the whole stream.
+    // - chunkSize always bigger than file size.
+    // - trigger multipart hk.notify()
+    let r = reader.read(chunkSize);
+    while (r) {
+        writer.write(r);
+        // reread end (undefined)
+        // and retrigger multipart hk.notify()
+        r = reader.read(chunkSize);
+    }
+}
+
 describe(module.id, () => {
     it('basic multipart/mixed', () => {
-        const source = testStream();
+        const source = testStreamMixed();
         const stream = source.transform(multipartParser(headers('mixed')));
         let part = stream.read();
         ok(part != null, 'part != null');
@@ -132,7 +162,7 @@ describe(module.id, () => {
 
     it('multipart/mixed roundtrip', () => {
         const heads = headers('mixed');
-        const source = testStream();
+        const source = testStreamMixed();
         const writer = bufferWriter();
         source
             .transform(multipartParser(heads))
@@ -193,5 +223,58 @@ describe(module.id, () => {
             .transform(multipartFormatter(heads))
             .pipe(writer2);
         strictEqual(result.toString('binary'), writer2.toBuffer().toString('binary'));
+    });
+
+    it('mutlipart/form-data with binaryReader and applying transformation', () => {
+        const expectedLength = [10 * 1024, 20 * 1024];
+
+        const heads = headers('form-data');
+        const source = testStreamFormData(
+            Buffer.alloc(expectedLength[0]).toString(),
+            Buffer.alloc(expectedLength[1]).toString(),
+        );
+
+        const receivedLength = [0, 0];
+        source
+            // Force stream to not be read in same event loop
+            .map(yieldMapper)
+            .transform(multipartParser(heads))
+            .forEach((partReader: Reader<Buffer>, i) => {
+                binaryReader(partReader)
+                    // This transform coupled with binaryReader triggers two final reads in part reader
+                    .transform(binaryToBufferReaderTransformer)
+                    .forEach(b => {
+                        receivedLength[i] += b.length;
+                    });
+
+                assert.equal(receivedLength[i], expectedLength[i]);
+            });
+    });
+
+    // Moving handshake does not fix the problem.
+    // I suspect a bug inside mixed parser function that does not support multiple read in part last chunk (return undefined),
+    // because of binaryReader with transformer
+    it.skip('mutlipart/mixed with binaryReader and applying transformation', () => {
+        const expectedLength = [10 * 1024, 20 * 1024];
+
+        const heads = headers('mixed');
+        const source = testStreamMixed(
+            Buffer.alloc(expectedLength[0]).toString(),
+            Buffer.alloc(expectedLength[1]).toString(),
+        );
+
+        const receivedLength = [0, 0];
+        source
+            .map(yieldMapper)
+            .transform(multipartParser(heads))
+            .forEach((partReader: Reader<Buffer>, i) => {
+                binaryReader(partReader)
+                    .transform(binaryToBufferReaderTransformer)
+                    .forEach(b => {
+                        receivedLength[i] += b.length;
+                    });
+
+                assert.equal(receivedLength[i], expectedLength[i]);
+            });
     });
 });

--- a/test/unit/multipart-test.ts
+++ b/test/unit/multipart-test.ts
@@ -1,16 +1,16 @@
 import { assert } from 'chai';
-import { IncomingHttpHeaders } from 'http';
 import { setup } from 'f-mocha';
 import { wait } from 'f-promise';
+import { IncomingHttpHeaders } from 'http';
 import {
+    BinaryReader,
+    binaryReader,
     bufferReader,
     bufferWriter,
     multipartFormatter,
     multipartParser,
     Reader,
     Writer,
-    BinaryReader,
-    binaryReader,
 } from '../..';
 
 setup();
@@ -114,12 +114,12 @@ function testStreamFormData(body1?: string, body2?: string): Reader<Buffer> {
 }
 
 function yieldMapper(buffer: Buffer) {
-    wait(cb => setImmediate(cb));
+    wait(setImmediate);
     return buffer;
 }
 
 function binaryToBufferReaderTransformer(reader: BinaryReader, writer: Writer<Buffer>) {
-    let chunkSize = 40 * 1024;
+    const chunkSize = 40 * 1024;
     // With our setting:
     // - read the whole stream.
     // - chunkSize always bigger than file size.


### PR DESCRIPTION
Bug:
applying a transformation on part reader encapsulated by binaryReader
causes corrupted multipart parts read. Final read for each part is
applied twice, so hk.notify() too. This implies hk.wait to be waked up
too soon.

Resolution:
Check part ended condition before notify handshake.