### PR TITLE
multipart: fix headers encoding

### DIFF
--- a/lib/transforms/multipart.ts
+++ b/lib/transforms/multipart.ts
@@ -40,12 +40,12 @@ function mixedParser(ct: MultipartContentType): (reader: Reader<Buffer>, writer:
         while (true) {
             const buf = binReader.readData(2048);
             if (!buf || !buf.length) return;
-            const str = buf.toString('utf8');
+            const str = buf.toString('binary');
             let i = str.indexOf(boundary);
             if (i < 0) throw new Error('boundary not found');
             const lines = str.substring(0, i).split(/\r?\n/);
             const headers = lines.slice(0, lines.length - 2).reduce((h: any, l: string) => {
-                const kv = l.split(/\s*:\s*/);
+                const kv = Buffer.from(l, 'binary').toString('utf8').split(/\s*:\s*/);
                 h[kv[0].toLowerCase()] = kv[1];
                 return h;
             }, {});
@@ -116,7 +116,7 @@ function formDataParser(ct: MultipartContentType): (reader: Reader<Buffer>, writ
             let partEnded = false;
             const buf = binReader.readData(2048);
             if (!buf || !buf.length) return;
-            const str = buf.toString('utf8');
+            const str = buf.toString('binary');
 
             let endBoundaryIndex = str.indexOf(boundary) + boundary.length;
             if (endBoundaryIndex < 0) throw new Error('boundary not found');
@@ -136,7 +136,7 @@ function formDataParser(ct: MultipartContentType): (reader: Reader<Buffer>, writ
 
             const lines = str.substring(endBoundaryIndex, endOfHeaders).split(/\r?\n/);
             const headers = lines.slice(0, lines.length).reduce((h: any, l: string) => {
-                const kv = l.split(/\s*:\s*/);
+                const kv = Buffer.from(l, 'binary').toString('utf8').split(/\s*:\s*/);
                 h[kv[0].toLowerCase()] = kv[1];
                 return h;
             }, {});

--- a/lib/transforms/multipart.ts
+++ b/lib/transforms/multipart.ts
@@ -50,7 +50,7 @@ function mixedParser(ct: MultipartContentType): (reader: Reader<Buffer>, writer:
                 return h;
             }, {});
             i = str.indexOf('\n', i);
-            binReader.unread(str.length - i - 1);
+            binReader.unread(buf.length - i - 1);
 
             const read = () => {
                 const len = Math.max(boundary.length, 256);
@@ -155,7 +155,7 @@ function formDataParser(ct: MultipartContentType): (reader: Reader<Buffer>, writ
                 beginOfData++;
             }
 
-            binReader.unread(str.length - beginOfData);
+            binReader.unread(buf.length - beginOfData);
 
             const read = () => {
                 const len = Math.max(boundary.length, 256);

--- a/lib/transforms/multipart.ts
+++ b/lib/transforms/multipart.ts
@@ -40,7 +40,7 @@ function mixedParser(ct: MultipartContentType): (reader: Reader<Buffer>, writer:
         while (true) {
             const buf = binReader.readData(2048);
             if (!buf || !buf.length) return;
-            const str = buf.toString('binary');
+            const str = buf.toString('utf8');
             let i = str.indexOf(boundary);
             if (i < 0) throw new Error('boundary not found');
             const lines = str.substring(0, i).split(/\r?\n/);
@@ -50,7 +50,7 @@ function mixedParser(ct: MultipartContentType): (reader: Reader<Buffer>, writer:
                 return h;
             }, {});
             i = str.indexOf('\n', i);
-            binReader.unread(buf.length - i - 1);
+            binReader.unread(str.length - i - 1);
 
             const read = () => {
                 const len = Math.max(boundary.length, 256);
@@ -95,7 +95,7 @@ function mixedFormatter(ct: MultipartContentType) {
             const headers = part.headers;
             if (!headers) throw new Error('part does not have headers');
             Object.keys(part.headers).forEach(key => {
-                writer.write(Buffer.from(key + ': ' + headers[key] + '\n', 'binary'));
+                writer.write(Buffer.from(key + ': ' + headers[key] + '\n', 'utf8'));
             });
             writer.write(Buffer.from('\n' + boundary + '\n'));
             // cannot use pipe because pipe writes undefined at end.
@@ -116,7 +116,7 @@ function formDataParser(ct: MultipartContentType): (reader: Reader<Buffer>, writ
             let partEnded = false;
             const buf = binReader.readData(2048);
             if (!buf || !buf.length) return;
-            const str = buf.toString('binary');
+            const str = buf.toString('utf8');
 
             let endBoundaryIndex = str.indexOf(boundary) + boundary.length;
             if (endBoundaryIndex < 0) throw new Error('boundary not found');
@@ -155,7 +155,7 @@ function formDataParser(ct: MultipartContentType): (reader: Reader<Buffer>, writ
                 beginOfData++;
             }
 
-            binReader.unread(buf.length - beginOfData);
+            binReader.unread(str.length - beginOfData);
 
             const read = () => {
                 const len = Math.max(boundary.length, 256);
@@ -214,7 +214,7 @@ function formDataFormatter(ct: MultipartContentType): (reader: Reader<Reader<Buf
             const headers = part.headers;
             if (!headers) throw new Error('part does not have headers');
             Object.keys(part.headers).forEach(key => {
-                writer.write(Buffer.from(key + ': ' + headers[key] + CR_LF, 'binary'));
+                writer.write(Buffer.from(key + ': ' + headers[key] + CR_LF, 'utf8'));
             });
             // cannot use pipe because pipe writes undefined at end.;
             writer.write(Buffer.from(CR_LF));

--- a/lib/transforms/multipart.ts
+++ b/lib/transforms/multipart.ts
@@ -32,6 +32,10 @@ function parseContentType(contentType?: string): MultipartContentType | null {
     };
 }
 
+function latin1toUtf8(text: string): string {
+    return Buffer.from(text, 'binary').toString('utf8');
+}
+
 function mixedParser(ct: MultipartContentType): (reader: Reader<Buffer>, writer: Writer<any>) => void {
     const boundary = ct.boundary;
     return (reader: Reader<Buffer>, writer: Writer<any>) => {
@@ -45,7 +49,7 @@ function mixedParser(ct: MultipartContentType): (reader: Reader<Buffer>, writer:
             if (i < 0) throw new Error('boundary not found');
             const lines = str.substring(0, i).split(/\r?\n/);
             const headers = lines.slice(0, lines.length - 2).reduce((h: any, l: string) => {
-                const kv = Buffer.from(l, 'binary').toString('utf8').split(/\s*:\s*/);
+                const kv = latin1toUtf8(l).split(/\s*:\s*/);
                 h[kv[0].toLowerCase()] = kv[1];
                 return h;
             }, {});
@@ -136,7 +140,7 @@ function formDataParser(ct: MultipartContentType): (reader: Reader<Buffer>, writ
 
             const lines = str.substring(endBoundaryIndex, endOfHeaders).split(/\r?\n/);
             const headers = lines.slice(0, lines.length).reduce((h: any, l: string) => {
-                const kv = Buffer.from(l, 'binary').toString('utf8').split(/\s*:\s*/);
+                const kv = latin1toUtf8(l).split(/\s*:\s*/);
                 h[kv[0].toLowerCase()] = kv[1];
                 return h;
             }, {});

--- a/test/unit/multipart-test.ts
+++ b/test/unit/multipart-test.ts
@@ -39,7 +39,7 @@ function testStreamMixed(body1?: string, body2?: string): ITestStreamData {
     const parts = [
         {
             headers: {
-                A: 'VÀ1',
+                A: 'Và1',
                 B: 'VB1',
                 'Content-Type': 'text/plain',
             },
@@ -73,7 +73,7 @@ function testStreamMixed(body1?: string, body2?: string): ITestStreamData {
     }
     return {
         reader: bufferReader(Buffer.from(parts.map(formatPart).join(''))),
-        expectedResult: 'a: VÀ1\nb: VB1\ncontent-type: text/plain\n\n------------myBoundary\nC1\n------------myBoundary\n' +
+        expectedResult: 'a: Và1\nb: VB1\ncontent-type: text/plain\n\n------------myBoundary\nC1\n------------myBoundary\n' +
             'content-type: text/plain\na: VA2\nb: VB2\n\n------------myBoundary\nC2\n------------myBoundary\n'
     };
 }
@@ -82,7 +82,7 @@ function testStreamFormData(body1?: string, body2?: string): ITestStreamData {
     const parts = [
         {
             headers: {
-                A: 'VÀ1',
+                A: 'Và1',
                 B: 'VB1',
                 'Content-Type': 'text/plain',
                 'content-disposition': 'form-data; name="c1";',
@@ -119,7 +119,7 @@ function testStreamFormData(body1?: string, body2?: string): ITestStreamData {
     }
     return {
         reader: bufferReader(Buffer.from(CR_LF + parts.map(formatPartWithFormData).join('') + CR_LF + '--' + boundary + '--')),
-        expectedResult: '--------------myBoundary\r\na: VÀ1\r\nb: VB1\r\ncontent-type: text/plain\r\n' +
+        expectedResult: '--------------myBoundary\r\na: Và1\r\nb: VB1\r\ncontent-type: text/plain\r\n' +
             'content-disposition: form-data; name=\"c1\";\r\n\r\nC1\r\n--------------myBoundary\r\ncontent-type: text/plain\r\n' +
             'content-disposition: form-data; name=\"c2\";\r\na: VA2\r\nb: VB2\r\n\r\nC2\r\n--------------myBoundary--'
     };
@@ -151,7 +151,7 @@ describe(module.id, () => {
         const stream = data.reader.transform(multipartParser(headers('mixed')));
         let part = stream.read();
         ok(part != null, 'part != null');
-        strictEqual(part.headers.a, 'VÀ1', 'header A');
+        strictEqual(part.headers.a, 'Và1', 'header A');
         strictEqual(part.headers.b, 'VB1', 'header B');
         strictEqual(part.headers['content-type'], 'text/plain', 'content-type');
         let r = part.read();
@@ -196,7 +196,7 @@ describe(module.id, () => {
         const stream = data.reader.transform(multipartParser(headers('form-data')));
         let part = stream.read();
         ok(part != null, 'part != null');
-        strictEqual(part.headers.a, 'VÀ1', 'header A');
+        strictEqual(part.headers.a, 'Và1', 'header A');
         strictEqual(part.headers.b, 'VB1', 'header B');
         strictEqual(part.headers['content-type'], 'text/plain', 'content-type');
         strictEqual(part.headers['content-disposition'], 'form-data; name="c1";', 'content-disposition');

--- a/test/unit/multipart-test.ts
+++ b/test/unit/multipart-test.ts
@@ -74,7 +74,7 @@ function testStreamMixed(body1?: string, body2?: string): ITestStreamData {
     return {
         reader: bufferReader(Buffer.from(parts.map(formatPart).join(''))),
         expectedResult: 'a: Và1\nb: VB1\ncontent-type: text/plain\n\n------------myBoundary\nC1\n------------myBoundary\n' +
-            'content-type: text/plain\na: VA2\nb: VB2\n\n------------myBoundary\nC2\n------------myBoundary\n'
+            'content-type: text/plain\na: VA2\nb: VB2\n\n------------myBoundary\nC2\n------------myBoundary\n',
     };
 }
 

--- a/test/unit/multipart-test.ts
+++ b/test/unit/multipart-test.ts
@@ -142,7 +142,7 @@ function binaryToBufferReaderTransformer(reader: BinaryReader, writer: Writer<Bu
     }
 }
 
-describe.only(module.id, () => {
+describe(module.id, () => {
     it('basic multipart/mixed', () => {
         const data = testStreamMixed();
         const stream = data.reader.transform(multipartParser(headers('mixed')));

--- a/test/unit/multipart-test.ts
+++ b/test/unit/multipart-test.ts
@@ -73,7 +73,8 @@ function testStreamMixed(body1?: string, body2?: string): ITestStreamData {
     }
     return {
         reader: bufferReader(Buffer.from(parts.map(formatPart).join(''))),
-        expectedResult: "a: VÀ1\nb: VB1\ncontent-type: text/plain\n\n------------myBoundary\nC1\n------------myBoundary\ncontent-type: text/plain\na: VA2\nb: VB2\n\n------------myBoundary\nC2\n------------myBoundary\n"
+        expectedResult: 'a: VÀ1\nb: VB1\ncontent-type: text/plain\n\n------------myBoundary\nC1\n------------myBoundary\n' +
+            'content-type: text/plain\na: VA2\nb: VB2\n\n------------myBoundary\nC2\n------------myBoundary\n'
     };
 }
 
@@ -118,7 +119,9 @@ function testStreamFormData(body1?: string, body2?: string): ITestStreamData {
     }
     return {
         reader: bufferReader(Buffer.from(CR_LF + parts.map(formatPartWithFormData).join('') + CR_LF + '--' + boundary + '--')),
-        expectedResult: '--------------myBoundary\r\na: VÀ1\r\nb: VB1\r\ncontent-type: text/plain\r\ncontent-disposition: form-data; name=\"c1\";\r\n\r\nC1\r\n--------------myBoundary\r\ncontent-type: text/plain\r\ncontent-disposition: form-data; name=\"c2\";\r\na: VA2\r\nb: VB2\r\n\r\nC2\r\n--------------myBoundary--'
+        expectedResult: '--------------myBoundary\r\na: VÀ1\r\nb: VB1\r\ncontent-type: text/plain\r\n' +
+            'content-disposition: form-data; name=\"c1\";\r\n\r\nC1\r\n--------------myBoundary\r\ncontent-type: text/plain\r\n' +
+            'content-disposition: form-data; name=\"c2\";\r\na: VA2\r\nb: VB2\r\n\r\nC2\r\n--------------myBoundary--'
     };
 }
 


### PR DESCRIPTION
When using multipartFormatter the part's header `content-disposition` could contain some bad encoded characters so some other multipart handlers like `multer` does not decode properly.
