### PR TITLE
emptyWriter: make it factory to be able to use it many times

### DIFF
--- a/lib/devices/file.ts
+++ b/lib/devices/file.ts
@@ -79,7 +79,7 @@ export function list(path: string, options?: ListOptions) {
         accept = arguments[2];
     }
     const postorder = recurse === 'postorder';
-    return generic.empty.reader.transform<ListEntry>((reader, writer) => {
+    return generic.empty.createReader().transform<ListEntry>((reader, writer) => {
         function process(p: string, name: string, depth: number) {
             const stat = wait(fs.stat(p));
             const entry = {

--- a/lib/devices/generic.ts
+++ b/lib/devices/generic.ts
@@ -5,13 +5,15 @@ import { Writer } from '../writer';
 ///
 /// `import { emptyReader, emptyWriter } from 'f-streams'`
 ///
-/// * `emptyReader`
-/// * `emptyWriter`
-///   Empty streams. `emptyReader.read()` returns `undefined`.
-///   `emptyWRiter` is a null sink. It just discards anything you would write to it.
+/// * `emptyReader` deprecated, use createEmptyReader()
+/// * `emptyWriter` deprecated, use createEmptyWriter()
+///   Empty streams. `createEmptyReader().read()` returns `undefined`.
+///   `createEmptyWriter()` create a null sink. It just discards anything you would write to it.
 export const empty = {
     reader: new Reader(function(this: Reader<any>) {}),
     writer: new Writer(function(this: Writer<any>, value: any) {}),
+    createReader: () => new Reader(function(this: Reader<any>) {}),
+    createWriter: () => new Writer(function(this: Writer<any>, value: any) {}),
 };
 
 /// !doc

--- a/lib/ez.ts
+++ b/lib/ez.ts
@@ -114,8 +114,12 @@ export {
     list as directoryReader,
 } from './devices/file';
 
+/** @deprecated - use createEmptyReader() instead */
 export const emptyReader = devices.generic.empty.reader;
+/** @deprecated - this writer is buggy, use createEmptyWriter() instead */
 export const emptyWriter = devices.generic.empty.writer;
+export const createEmptyReader = devices.generic.empty.createReader;
+export const createEmptyWriter = devices.generic.empty.createWriter;
 export { reader as genericReader, writer as genericWriter } from './devices/generic';
 
 export {

--- a/test/unit/ez-test.ts
+++ b/test/unit/ez-test.ts
@@ -1,10 +1,11 @@
 import { assert } from 'chai';
 import { setup } from 'f-mocha';
-import { run, wait } from 'f-promise';
-import { cutter, HttpServer, httpServer, reader as fReader, writer as fWriter } from '../..';
+import { cutter, emptyReader, HttpServer, httpServer, reader as fReader, writer as fWriter } from '../..';
+import { createEmptyReader, createEmptyWriter } from '../../lib';
+
 setup();
 
-const { equal, ok, strictEqual, deepEqual } = assert;
+const { ok, strictEqual, deepEqual } = assert;
 
 let server: HttpServer;
 
@@ -101,5 +102,22 @@ describe(module.id, () => {
         const writer = fWriter(Buffer.alloc(0));
         const reply = fReader(buf).pipe(writer);
         deepEqual(writer.result.toString('utf8'), buf.toString('utf8'));
+    });
+
+    it('emptyReader should be usable many times', () => {
+        assert.isUndefined(emptyReader.readAll());
+        assert.isUndefined(emptyReader.readAll());
+    });
+
+    it('createEmptyReader() should be usable many times', () => {
+        assert.isUndefined(createEmptyReader().readAll());
+        assert.isUndefined(createEmptyReader().readAll());
+    });
+
+    it('createEmptyWriter() should be usable many times', () => {
+        assert.doesNotThrow(() => {
+            fReader('string:hello world').pipe(createEmptyWriter());
+            fReader([2, 3, 4]).pipe(createEmptyWriter());
+        });
     });
 });


### PR DESCRIPTION
emptyWriter was usable only once, so create a new one each time.
=> change interface but I guess it is not really used.
