### PR TITLE
fix factory memory usage

### DIFF
--- a/lib/factory.ts
+++ b/lib/factory.ts
@@ -22,7 +22,7 @@ function scanDirs(dir: string) {
         if (!fs.existsSync(pkgPath)) return;
         try {
             // add factories from package.json
-            const pk = require(pkgPath);
+            const pk = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
             if (pk && pk.f && pk.f.factories) {
                 pk.f.factories.forEach((crt: PackageFactory) => {
                     if (crt.protocol && crt.module) {


### PR DESCRIPTION
By doing 'require' for many package.json found in node_modules and parent directory, the scanDirs function load many useless modules in memory. Replace require by fs.readFileSync allow gc to free memory.

On my project, 580 modules before, 44 after. About 3Mb. (by doing juste a require('f-streams') in node --inspect run in project dir).

Also, I wonder if this feature is used. not a word in documentation. I would propose to remove it.

@tchambard 