### PR TITLE
Fix silent stop with uturn (reader.dup)

### DIFF
--- a/lib/devices/uturn.ts
+++ b/lib/devices/uturn.ts
@@ -99,7 +99,7 @@ export function create<T>(): Uturn<T> {
                         case 'reading':
                             state = 'done';
                             // send undefined or exception to read
-                            bounceReader(arg && arg !== 1 ? arg : null);
+                            bounceReader(arg && arg !== true ? arg : null);
                             // acknowledge the stop
                             cb(undefined);
                             break;
@@ -171,7 +171,7 @@ export function create<T>(): Uturn<T> {
                         case 'reading':
                             // send undefined or exception to read
                             state = 'done';
-                            bounceReader(arg && arg !== 1 ? arg : null);
+                            bounceReader(arg && arg !== true ? arg : null);
                             // acknowledge the stop
                             cb(undefined);
                             break;

--- a/test/unit/stop-test.ts
+++ b/test/unit/stop-test.ts
@@ -2,6 +2,7 @@ import { assert } from 'chai';
 import { setup } from 'f-mocha';
 import { run, wait } from 'f-promise';
 import { arrayWriter, genericReader, Reader } from '../..';
+import { nextTick } from '../../lib/util';
 setup();
 
 const { equal, ok, strictEqual, deepEqual } = assert;
@@ -17,6 +18,7 @@ function numbers(limit: number): TestReader {
     let i = 0;
     return genericReader(
         function read(this: TestReader) {
+            nextTick();
             if (this.stoppedReason) throw new Error('attempt to read after stop: ' + i);
             return i >= limit ? undefined : i++;
         },


### PR DESCRIPTION
- Using async reader (nextTick) reveal an uncorrect behavior of reader.stop() when using "true" as argument as specified in methode documentation.
The reader should stop silently (read should return undefined), but it was not the case anymore in this test.
- uturn.ts:174 fixes stop-test.ts "dup stops both silently from 0"
- uturn.ts:102 seem to have same error, but can demonstrate it in unit-tests

@tchambard 